### PR TITLE
Adds cmd functionality, adapts case tests to new usage method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![ubuntu-gnu](https://github.com/OpenSEMBA/dgtd/actions/workflows/ubuntu-gnu.yml/badge.svg)](https://github.com/OpenSEMBA/dgtd/actions/workflows/ubuntu-gnu.yml)
-[![windows-msvc](https://github.com/OpenSEMBA/dgtd/actions/workflows/windows-msvc.yml/badge.svg?branch=alejandro)](https://github.com/OpenSEMBA/dgtd/actions/workflows/windows-msvc.yml)
+[![windows-msvc](https://github.com/OpenSEMBA/dgtd/actions/workflows/windows-msvc.yml/badge.svg)](https://github.com/OpenSEMBA/dgtd/actions/workflows/windows-msvc.yml)
 
 # semba-dgtd
 Maxwell's curl equations solver using discontinuous Galerkin methods

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,11 @@ if (MAXWELL_USE_MPI)
 	add_compile_definitions(MAXWELL_USE_MPI)
 endif()
 
+add_subdirectory(launcher)
 add_subdirectory(driver)
 add_subdirectory(components)
 add_subdirectory(evolution)
 add_subdirectory(math)
 add_subdirectory(mfemExtension)
 add_subdirectory(solver)
+

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -488,6 +488,7 @@ void postProcessInformation(const json& case_data, maxwell::Model& model)
 
 maxwell::Solver buildSolver(const json& case_data, const std::string& case_path, const bool isTest)
 {
+	
 	maxwell::Model model{ buildModel(case_data, case_path, isTest) };
 	maxwell::Probes probes{ buildProbes(case_data) };
 	maxwell::Sources sources{ buildSources(case_data) };

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -277,6 +277,26 @@ std::string assembleMeshString(const std::string& filename)
 	return maxwellInputsFolder() + folder_name + "/" + filename;
 }
 
+std::string assembleLauncherMeshString(const std::string& mesh_name, const std::string& case_path)
+{
+	std::string path{ case_path };
+	std::string s_json = ".json";
+	std::string s_msh  = ".msh";
+	std::string s_mesh = ".mesh";
+
+	std::string::size_type input_json = path.find(s_json);
+	std::string::size_type input_msh = mesh_name.find(s_msh);
+	std::string::size_type input_mesh = mesh_name.find(s_mesh);
+
+	path.erase(input_json, s_json.length());
+	if (input_msh != std::string::npos)
+		path.append(s_msh);
+	if (input_mesh != std::string::npos)
+		path.append(s_mesh);
+
+	return path;
+}
+
 void checkIfAttributesArePresent(const Mesh& mesh, const GeomTagToMaterialInfo& info)
 {
 
@@ -409,15 +429,26 @@ mfem::Mesh assembleMeshNoFix(const std::string& mesh_string)
 	return mfem::Mesh::LoadFromFileNoBdrFix(mesh_string, 1, 0, true);
 }
 
-Model buildModel(const json& case_data)
+Model buildModel(const json& case_data, const std::string& case_path, const bool isTest)
 {
-	auto mesh{ assembleMesh(assembleMeshString(case_data["model"]["filename"])) };
+	mfem::Mesh mesh;
+	if (isTest) {
+		mesh = assembleMesh(assembleMeshString(case_data["model"]["filename"]));
+	}
+	else {
+		mesh = assembleMesh(assembleLauncherMeshString(case_data["model"]["filename"], case_path));
+	}
 
 	auto att_to_material{ assembleAttributeToMaterial(case_data, mesh) };
 	auto att_to_bdr_info{ assembleAttributeToBoundary(case_data, mesh) };
 
 	if (!att_to_bdr_info.gt2b.empty() && !att_to_material.gt2m.empty()) {
-		mesh = assembleMeshNoFix(assembleMeshString(case_data["model"]["filename"]));
+		if (isTest) {
+			mesh = assembleMesh(assembleMeshString(case_data["model"]["filename"]));
+		}
+		else {
+			mesh = assembleMesh(assembleLauncherMeshString(case_data["model"]["filename"], case_path));
+		}
 	}
 
 	return Model(mesh, att_to_material, att_to_bdr_info);
@@ -429,11 +460,11 @@ json parseJSONfile(const std::string& case_name)
 	return json::parse(test_file);
 }
 
-maxwell::Solver buildSolver(const std::string& case_name)
+maxwell::Solver buildSolverJson(const std::string& case_name, const bool isTest)
 {
 	auto case_data{ parseJSONfile(case_name) };
 
-	return buildSolver(case_data);
+	return buildSolver(case_data, case_name, isTest);
 }
 
 void postProcessInformation(const json& case_data, maxwell::Model& model) 
@@ -455,9 +486,9 @@ void postProcessInformation(const json& case_data, maxwell::Model& model)
 	}
 }
 
-maxwell::Solver buildSolver(const json& case_data)
+maxwell::Solver buildSolver(const json& case_data, const std::string& case_path, const bool isTest)
 {
-	maxwell::Model model{ buildModel(case_data) };
+	maxwell::Model model{ buildModel(case_data, case_path, isTest) };
 	maxwell::Probes probes{ buildProbes(case_data) };
 	maxwell::Sources sources{ buildSources(case_data) };
 	maxwell::SolverOptions solverOpts{ buildSolverOptions(case_data) };

--- a/src/driver/driver.h
+++ b/src/driver/driver.h
@@ -18,13 +18,13 @@ namespace maxwell::driver {
 
 	json parseJSONfile(const std::string& case_name);
 
-	maxwell::Solver buildSolver(const std::string& case_name);
-	maxwell::Solver buildSolver(const json& case_data);
+	maxwell::Solver buildSolverJson(const std::string& case_name, const bool isTest = true);
+	maxwell::Solver buildSolver(const json& case_data, const std::string& case_path, const bool isTest);
 
 	std::string assembleMeshString(const std::string& filename);
 
 	Probes buildProbes(const json& case_data);
 	SolverOptions buildSolverOptions(const json& case_data);
 	Sources buildSources(const json& case_data);
-	Model buildModel(const json& case_data);
+	Model buildModel(const json& case_data, const std::string& case_path, const bool isTest);
 }

--- a/src/evolution/Evolution.h
+++ b/src/evolution/Evolution.h
@@ -7,6 +7,8 @@
 #include "EvolutionMethods.h"
 #include "components/SubMesher.h"
 
+#include <chrono>
+
 namespace maxwell {
 
 class Evolution: public mfem::TimeDependentOperator {

--- a/src/launcher/CMakeLists.txt
+++ b/src/launcher/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+
+message(STATUS "Creating build system for opensemba_dgtd")
+
+add_executable(opensemba_dgtd "launcher.cpp")
+
+target_link_libraries(opensemba_dgtd 
+		maxwell-driver 
+		mfem
+)

--- a/src/launcher/launcher.cpp
+++ b/src/launcher/launcher.cpp
@@ -36,9 +36,16 @@ int main(int argc, char** argv)
 		}
 		else if (std::string(argv[i]) == "-h") {
 			printHelpArgument();
-			system("pause");
 			return 2;
 		}
+	}
+
+	std::string s_json = ".json";
+	std::string::size_type input_msh = inputFilePath.find(s_json);
+	if (input_msh == std::string::npos)
+	{
+		std::cerr << "Input File is not a .json file." << std::endl;
+		return 3;
 	}
 
 	auto solver = maxwell::driver::buildSolverJson(inputFilePath, false);

--- a/src/launcher/launcher.cpp
+++ b/src/launcher/launcher.cpp
@@ -1,0 +1,51 @@
+#include <string>
+#include <vector>
+#include <iostream>
+
+#include "driver/driver.h"
+
+void printHelpArgument() 
+{
+	std::cout << "                               OpenSEMBA/dgtd                              "  << std::endl;
+	std::cout << "___________________________________________________________________________"  << std::endl;
+	std::cout <<																				   std::endl;
+	std::cout << "Command line arguments:"                                                      << std::endl;
+	std::cout <<																				   std::endl;
+	std::cout << "___________________________________________________________________________"  << std::endl;
+	std::cout <<																				   std::endl;
+	std::cout << "-h              / Brings up this help menu."								    << std::endl;
+	std::cout << "-i path/to/file / Specifies input file to run with executable."			    << std::endl;
+	std::cout <<																				   std::endl;
+	std::cout << "___________________________________________________________________________"  << std::endl;
+}
+
+int main(int argc, char** argv)
+{
+	
+	if (argc == 1) {
+		std::cerr << "Missing arguments. Use argument -h to print help menu.";
+		return 1;
+	}
+	
+	std::string inputFilePath;
+
+	for (int i = 1; i < argc; ++i) {
+		std::string arg = argv[i];
+		if (std::string(argv[i]) == "-i" && i + 1 < argc) {
+			inputFilePath = argv[++i]; 
+		}
+		else if (std::string(argv[i]) == "-h") {
+			printHelpArgument();
+			system("pause");
+			return 2;
+		}
+	}
+
+	auto solver = maxwell::driver::buildSolverJson(inputFilePath, false);
+	solver.run();
+
+	std::cout << "Solver has finished performing its operations." << std::endl;
+	std::cout << "Program will end now." << std::endl;
+
+	return 0;
+}

--- a/src/launcher/launcher.cpp
+++ b/src/launcher/launcher.cpp
@@ -40,8 +40,8 @@ int main(int argc, char** argv)
 		}
 	}
 
-	std::string s_json = ".json";
-	std::string::size_type input_msh = inputFilePath.find(s_json);
+	const std::string s_json = ".json";
+	const std::string::size_type input_msh = inputFilePath.find(s_json);
 	if (input_msh == std::string::npos)
 	{
 		std::cerr << "Input File is not a .json file." << std::endl;

--- a/src/solver/Solver.cpp
+++ b/src/solver/Solver.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <iostream>
 #include <algorithm>
+#include <chrono>
 
 using namespace mfem;
 
@@ -190,10 +191,37 @@ double Solver::estimateTimeStep() const
 	}
 }
 
+void printSimulationInformation(const double time, const double dt, const double finalTime)
+{
+	std::cout << "------------------------------------------------" << std::endl;
+	std::cout << std::endl;
+	std::cout << "Information is updated every 30 seconds." << std::endl;
+	std::cout << "Current Step: " + std::to_string(int(time / dt)) << std::endl;
+	std::cout << "Steps Left  : " + std::to_string(int((finalTime - time) / dt)) << std::endl;
+	std::cout << std::endl;
+	std::cout << "Final Time  : " + std::to_string(finalTime / physicalConstants::speedOfLight_SI * 1e9) + " ns." << std::endl;
+	std::cout << "Current Time: " + std::to_string(time / physicalConstants::speedOfLight_SI * 1e9) + " ns." << std::endl;
+	std::cout << "Time Step   : " + std::to_string(dt / physicalConstants::speedOfLight_SI * 1e9) + " ns." << std::endl;
+	std::cout << std::endl;
+}
+
 void Solver::run()
 {
+	auto lastPrintTime{ std::chrono::steady_clock::now() };
+	std::cout << "------------------------------------------------" << std::endl;
+	std::cout << "-------------SOLVER RUN INFORMATION-------------" << std::endl;
+	printSimulationInformation(time_, dt_, opts_.finalTime);
 	while (time_ <= opts_.finalTime - 1e-8*dt_) {
+
 		step();
+
+		auto currentTime = std::chrono::steady_clock::now();
+		if (std::chrono::duration_cast<std::chrono::seconds>
+			(currentTime - lastPrintTime).count() >= 30.0) 
+		{
+			printSimulationInformation(time_, dt_, opts_.finalTime);
+			lastPrintTime = currentTime;
+		}
 	}
 }
 

--- a/test/cases/CasesTest.cpp
+++ b/test/cases/CasesTest.cpp
@@ -16,7 +16,7 @@ TEST_F(CasesTest, 1D_PEC_Upwind)
 {
 
 	std::string case_name{ "1D_PEC" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	GridFunction eOld{ solver.getField(E,Y) };
 	auto normOld{ solver.getFields().getNorml2() };
@@ -77,7 +77,7 @@ TEST_F(CasesTest, 1D_TFSF_Centered)
 {
 	auto case_data{ parseJSONfile(maxwellCase("1D_TFSF")) };
 	case_data["solver_options"]["solver_type"] = "centered";
-	auto solver{ buildSolver(case_data) };
+	auto solver{ buildSolver(case_data, maxwellCase("1D_TFSF"), true) };
 
 	auto normOld{ solver.getFields().getNorml2() };
 	EXPECT_EQ(0.0, normOld);
@@ -148,7 +148,7 @@ TEST_F(CasesTest, 1D_TFSF_Centered)
 TEST_F(CasesTest, 1D_TFSF_Upwind_TEy)
 {
 	std::string case_name{ "1D_TFSF_TEy" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	auto normOld{ solver.getFields().getNorml2() };
 	EXPECT_EQ(0.0, normOld);
@@ -217,7 +217,7 @@ TEST_F(CasesTest, 1D_TFSF_Upwind_TEy)
 TEST_F(CasesTest, 1D_TFSF_Upwind_THz)
 {
 	std::string case_name{ "1D_TFSF_THz" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	auto normOld{ solver.getFields().getNorml2() };
 	EXPECT_EQ(0.0, normOld);
@@ -289,7 +289,7 @@ TEST_F(CasesTest, 2D_PEC_Centered)
 {
 	auto case_data{ parseJSONfile(maxwellCase("2D_PEC")) };
 	case_data["solver_options"]["solver_type"] = "centered";
-	auto solver{ buildSolver(case_data) };
+	auto solver{ buildSolver(case_data, maxwellCase("2D_PEC"), true) };
 
 	GridFunction eOld{ solver.getField(E,Z) };
 	auto normOld{ solver.getFields().getNorml2() };
@@ -353,7 +353,7 @@ TEST_F(CasesTest, 2D_PEC_Centered)
 TEST_F(CasesTest, 2D_PEC_Upwind)
 {
 	std::string case_name{"2D_PEC"};
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	GridFunction eOld{ solver.getField(E,Z) };
 	auto normOld{ solver.getFields().getNorml2() };
@@ -417,7 +417,7 @@ TEST_F(CasesTest, 2D_TFSF_Centered)
 {
 	auto case_data{ parseJSONfile(maxwellCase("2D_TFSF_TEy")) };
 	case_data["solver_options"]["solver_type"] = "centered";
-	auto solver{ buildSolver(case_data) };
+	auto solver{ buildSolver(case_data, maxwellCase("2D_TFSF_TEy"), true) };
 
 	auto normOld{ solver.getFields().getNorml2() };
 	EXPECT_EQ(0.0, normOld);
@@ -487,7 +487,7 @@ TEST_F(CasesTest, 2D_TFSF_Centered)
 TEST_F(CasesTest, 2D_TFSF_Upwind_TEy)
 {
 	std::string case_name{ "2D_TFSF_TEy" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	auto normOld{ solver.getFields().getNorml2() };
 	EXPECT_EQ(0.0, normOld);
@@ -557,7 +557,7 @@ TEST_F(CasesTest, 2D_TFSF_Upwind_TEy)
 TEST_F(CasesTest, 2D_TFSF_Upwind_THz)
 {
 	std::string case_name{ "2D_TFSF_THz" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	auto normOld{ solver.getFields().getNorml2() };
 	EXPECT_EQ(0.0, normOld);
@@ -627,7 +627,7 @@ TEST_F(CasesTest, 2D_TFSF_Upwind_THz)
 TEST_F(CasesTest, 2D_Conductivity_Upwind)
 {
 	auto case_data{ parseJSONfile(maxwellCase("2D_COND")) };
-	auto solver{ buildSolver(case_data) };
+	auto solver{ buildSolverJson(case_data) };
 
 	solver.run();
 }
@@ -635,7 +635,7 @@ TEST_F(CasesTest, 2D_Conductivity_Upwind)
 TEST_F(CasesTest, 2D_Conductivity_Angled_Upwind)
 {
 	auto case_data{ parseJSONfile(maxwellCase("2D_COND_ANGLED")) };
-	auto solver{ buildSolver(case_data) };
+	auto solver{ buildSolverJson(case_data) };
 
 	solver.run();
 }
@@ -643,7 +643,7 @@ TEST_F(CasesTest, 2D_Conductivity_Angled_Upwind)
 TEST_F(CasesTest, DISABLED_2D_NTFF_Box_Upwind) //Unsupported Gmsh element type.
 {
 	std::string case_name{ "2D_NTFF_Box" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -651,7 +651,7 @@ TEST_F(CasesTest, DISABLED_2D_NTFF_Box_Upwind) //Unsupported Gmsh element type.
 TEST_F(CasesTest, 2D_RCS_SubLambda_Hz)
 {
 	std::string case_name{ "2D_RCS" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -659,7 +659,7 @@ TEST_F(CasesTest, 2D_RCS_SubLambda_Hz)
 TEST_F(CasesTest, 2D_RCS_ThreeLambda_Hz)
 {
 	std::string case_name{ "2D_RCS_ThreeLambda" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -667,7 +667,7 @@ TEST_F(CasesTest, 2D_RCS_ThreeLambda_Hz)
 TEST_F(CasesTest, 2D_RCS_Salva_Hz)
 {
 	std::string case_name{ "2D_RCS_Salva" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -675,7 +675,7 @@ TEST_F(CasesTest, 2D_RCS_Salva_Hz)
 TEST_F(CasesTest, 2D_RCS_SalvaConfig_Hz)
 {
 	std::string case_name{ "2D_RCS_SalvaConfig" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -683,7 +683,7 @@ TEST_F(CasesTest, 2D_RCS_SalvaConfig_Hz)
 TEST_F(CasesTest, 2D_PEC_Bounce45_Upwind)
 {
 	std::string case_name{ "2D_PEC_Bounce" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -692,7 +692,7 @@ TEST_F(CasesTest, 3D_TFSF_Centered)
 {
 	auto case_data{ parseJSONfile(maxwellCase("3D_TFSF")) };
 	case_data["solver_options"]["solver_type"] = "centered";
-	auto solver{ buildSolver(case_data) };
+	auto solver{ buildSolver(case_data, maxwellCase("3D_TFSF"), true) };
 
 	auto normOld{ solver.getFields().getNorml2() };
 	EXPECT_EQ(0.0, normOld);
@@ -762,7 +762,7 @@ TEST_F(CasesTest, 3D_TFSF_Centered)
 TEST_F(CasesTest, 3D_TFSF_Upwind)
 {
 	std::string case_name{ "3D_TFSF" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	auto normOld{ solver.getFields().getNorml2() };
 	EXPECT_EQ(0.0, normOld);
@@ -832,7 +832,7 @@ TEST_F(CasesTest, 3D_TFSF_Upwind)
 TEST_F(CasesTest, 3D_NearToFarField_Upwind)
 {
 	std::string case_name{ "3D_NearToFarField" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -840,7 +840,7 @@ TEST_F(CasesTest, 3D_NearToFarField_Upwind)
 TEST_F(CasesTest, 3D_NearToFarFieldSmaller_Upwind)
 {
 	std::string case_name{ "3D_NearToFarFieldSmaller" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -848,7 +848,7 @@ TEST_F(CasesTest, 3D_NearToFarFieldSmaller_Upwind)
 TEST_F(CasesTest, 3D_TFSF_InteriorPEC_Upwind)
 {
 	std::string case_name{ "3D_TFSF_InteriorPEC" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 
@@ -957,7 +957,7 @@ TEST_F(CasesTest, 3D_TFSF_InteriorPEC_Upwind)
 TEST_F(CasesTest, 3D_NTFF_Sphere_Upwind)
 {
 	std::string case_name{ "3D_RCS" };
-	auto solver{ buildSolver(maxwellCase(case_name)) };
+	auto solver{ buildSolverJson(maxwellCase(case_name)) };
 
 	solver.run();
 }
@@ -965,7 +965,7 @@ TEST_F(CasesTest, 3D_NTFF_Sphere_Upwind)
 TEST_F(CasesTest, 3D_Conductivity_Upwind)
 {
 	auto case_data{ parseJSONfile(maxwellCase("3D_COND")) };
-	auto solver{ buildSolver(case_data) };
+	auto solver{ buildSolverJson(case_data) };
 
 	solver.run();
 

--- a/test/maxwell/driver/DriverTest.cpp
+++ b/test/maxwell/driver/DriverTest.cpp
@@ -59,8 +59,8 @@ TEST_F(DriverTest, adaptsModelObjects)
 	std::ifstream test_file(file_name);
 	auto case_data = json::parse(test_file);
 
-	EXPECT_NO_THROW(buildModel(case_data));
-	auto model{ buildModel(case_data) };	
+	EXPECT_NO_THROW(buildModel(case_data, file_name, true));
+	auto model{ buildModel(case_data, file_name, true) };
 
 	EXPECT_NO_THROW(model.getConstMesh());
 	


### PR DESCRIPTION
Cases can now be launched by running the new executable 'opensemba_dgtd.exe'.
Basic usage help can be printed by using no arguments.
Help is printed by using the -h argument.
Cases can be launched by using the -i argument along with the path to the .json file.
.json and mesh file have to be in the same folder.
Executable can be launched from any folder, and is not restricted to being launched inside the case folder or bin folder.
Executable accepts relative and absolute routes to case folders.