### PR TITLE
Refactor GlobalEvolution to use a single mutable work vector, changes DGOperatorFactory to simplify instructions and precompute CSR

### DIFF
--- a/.github/workflows/ubuntu-gnu.yml
+++ b/.github/workflows/ubuntu-gnu.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   

--- a/src/components/DGOperatorFactory.h
+++ b/src/components/DGOperatorFactory.h
@@ -148,6 +148,93 @@ namespace maxwell
 
 	void loadBlockInGlobalAtIndices(const SparseMatrix &blk, SparseMatrix &dst, const std::pair<Array<int>, Array<int>> &ids, const double fieldSign = 1.0);
 
+	/// A block placement for CSR-direct assembly (S1 optimization).
+	/// Stores a finalized sub-operator and its position within the global matrix.
+	struct CSRBlockPlacement {
+		std::unique_ptr<SparseMatrix> block;  ///< Finalized CSR sub-operator.
+		int rowOffset;                        ///< Global row offset for this block.
+		int colOffset;                        ///< Global column offset for this block.
+		double sign;                          ///< Scaling factor (±1).
+	};
+
+	/// Collect a sub-operator block placement instead of scattering into a LIL matrix.
+	/// The block's CSR data is copied (for operators placed at multiple offsets).
+	inline void collectBlockPlacement(
+		const SparseMatrix& blk,
+		std::vector<CSRBlockPlacement>& blocks,
+		const std::pair<FieldOffsets, FieldOffsets>& ids,
+		double fieldSign)
+	{
+		blocks.push_back(CSRBlockPlacement{
+			std::make_unique<SparseMatrix>(blk),
+			ids.first.rowStartOffset,
+			ids.second.colStartOffset,
+			fieldSign
+		});
+	}
+
+	/// Merge collected CSR block placements into a single finalized CSR SparseMatrix.
+	/// Uses a two-pass marker technique (like MFEM's Add) to avoid LIL overhead.
+	inline std::unique_ptr<SparseMatrix> mergeBlocksToCSR(
+		std::vector<CSRBlockPlacement>& blocks,
+		int globalRows, int globalCols)
+	{
+		// Pass 1: Count unique column entries per global row.
+		std::vector<int> marker(globalCols, -1);
+		int* C_i = mfem::Memory<int>(globalRows + 1);
+		C_i[0] = 0;
+
+		for (int row = 0; row < globalRows; ++row) {
+			int nnz = 0;
+			for (auto& bp : blocks) {
+				const int localRow = row - bp.rowOffset;
+				if (localRow < 0 || localRow >= bp.block->Height()) continue;
+				const int rowNNZ = bp.block->RowSize(localRow);
+				const int* cols = bp.block->GetRowColumns(localRow);
+				for (int k = 0; k < rowNNZ; ++k) {
+					int globalCol = cols[k] + bp.colOffset;
+					if (marker[globalCol] != row) {
+						marker[globalCol] = row;
+						++nnz;
+					}
+				}
+			}
+			C_i[row + 1] = C_i[row] + nnz;
+		}
+
+		const int totalNNZ = C_i[globalRows];
+		int* C_j = mfem::Memory<int>(totalNNZ);
+		real_t* C_data = mfem::Memory<real_t>(totalNNZ);
+
+		// Pass 2: Fill J and A arrays, merging duplicate column entries.
+		std::fill(marker.begin(), marker.end(), -1);
+		int pos = 0;
+		for (int row = 0; row < globalRows; ++row) {
+			for (auto& bp : blocks) {
+				const int localRow = row - bp.rowOffset;
+				if (localRow < 0 || localRow >= bp.block->Height()) continue;
+				const int rowNNZ = bp.block->RowSize(localRow);
+				const int* cols = bp.block->GetRowColumns(localRow);
+				const real_t* vals = bp.block->GetRowEntries(localRow);
+				for (int k = 0; k < rowNNZ; ++k) {
+					int globalCol = cols[k] + bp.colOffset;
+					if (marker[globalCol] < C_i[row]) {
+						// New entry for this row.
+						C_j[pos] = globalCol;
+						C_data[pos] = vals[k] * bp.sign;
+						marker[globalCol] = pos;
+						++pos;
+					} else {
+						// Duplicate column — accumulate.
+						C_data[marker[globalCol]] += vals[k] * bp.sign;
+					}
+				}
+			}
+		}
+
+		return std::make_unique<SparseMatrix>(C_i, C_j, C_data, globalRows, globalCols);
+	}
+
 	template <typename FES>
 	class DGOperatorFactory
 	{
@@ -229,7 +316,49 @@ namespace maxwell
 		template <typename BF>
 		void addGlobalTwoNormalOperators(mfem::SparseMatrix* global);
 		template <typename BF>
-		void addGlobalConductiveOperator(mfem::SparseMatrix* global); 
+		void addGlobalConductiveOperator(mfem::SparseMatrix* global);
+
+		// Overloads accepting pre-computed M^{-1} to avoid redundant rebuilds.
+		template <typename BF>
+		void addGlobalZeroNormalIBFIOperators(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalOneNormalIBFIOperators(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalTwoNormalIBFIOperators(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalDirectionalOperators(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalZeroNormalOperators(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalOneNormalOperators(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalTwoNormalOperators(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalConductiveOperator(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalSourceFaceIBFIZeroNormalOperators(mfem::SparseMatrix* global, mfem::Array<int>& marker, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalSourceFaceIBFIOneNormalOperators(mfem::SparseMatrix* global, mfem::Array<int>& marker, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void addGlobalSourceFaceIBFITwoNormalOperators(mfem::SparseMatrix* global, mfem::Array<int>& marker, const std::array<std::unique_ptr<BF>, 2>& MInv); 
+
+		// S1: Overloads that collect block placements for CSR-direct assembly.
+		template <typename BF>
+		void collectGlobalZeroNormalIBFIOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void collectGlobalOneNormalIBFIOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void collectGlobalTwoNormalIBFIOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void collectGlobalDirectionalOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void collectGlobalZeroNormalOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void collectGlobalOneNormalOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void collectGlobalTwoNormalOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv);
+		template <typename BF>
+		void collectGlobalConductiveOperator(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv);
 
 		std::unique_ptr<mfem::SparseMatrix> buildTFSFGlobalOperator();
 		std::unique_ptr<mfem::SparseMatrix> buildSGBCGlobalOperator();
@@ -265,6 +394,11 @@ namespace maxwell
 				return fes_.num_face_nbr_dofs;
 			}
 			return 0;
+		}
+
+		int meshDimension() const
+		{
+			return fes_.GetMesh()->Dimension();
 		}
 	};
 
@@ -730,9 +864,16 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalZeroNormalIBFIOperators(SparseMatrix* global)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalZeroNormalIBFIOperators<BF>(global, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalZeroNormalIBFIOperators(SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			auto op = buildByMult<FES,BF>(
 				MInv[f]->SpMat(), buildZeroNormalIBFISubOperator<BF>(f)->SpMat(), fes_);
 			for (auto d : { X, Y, Z }) {
@@ -750,10 +891,19 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalOneNormalIBFIOperators(SparseMatrix* global)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalOneNormalIBFIOperators<BF>(global, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalOneNormalIBFIOperators(SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			for (auto x{ X }; x <= Z; x++) {
+				if (x >= dim) continue; // S2: normal component x is zero in lower dimensions
 				auto y = (x + 1) % 3;
 				auto z = (x + 2) % 3;
 				auto op = buildByMult<FES,BF>(MInv[f]->SpMat(), buildOneNormalIBFISubOperator<BF>(altField(f), { x })->SpMat(), fes_);
@@ -777,11 +927,21 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalTwoNormalIBFIOperators(SparseMatrix* global)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalTwoNormalIBFIOperators<BF>(global, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalTwoNormalIBFIOperators(SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			for (auto d{ X }; d <= Z; d++) {
+				if (d >= dim) continue; // S2: normal component d is zero in lower dimensions
 				for (auto d2{ X }; d2 <= Z; d2++) {
+					if (d2 >= dim) continue; // S2: normal component d2 is zero in lower dimensions
 					auto op = buildByMult<FES,BF>(MInv[f]->SpMat(), buildTwoNormalIBFISubOperator<BF>(f, { d, d2 })->SpMat(), fes_);
 					loadBlockInGlobalAtIndices(
 						op->SpMat(),
@@ -798,9 +958,16 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalSourceFaceIBFIZeroNormalOperators(SparseMatrix* global, mfem::Array<int>& marker)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalSourceFaceIBFIZeroNormalOperators<BF>(global, marker, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalSourceFaceIBFIZeroNormalOperators(SparseMatrix* global, mfem::Array<int>& marker, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			auto op = buildByMult<FES,BF>(
 				MInv[f]->SpMat(), buildSourceFaceIBFIZeroNormalSubOperator<BF>(f, marker)->SpMat(), fes_);
 			for (auto d : { X, Y, Z }) {
@@ -818,10 +985,19 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalSourceFaceIBFIOneNormalOperators(SparseMatrix* global, mfem::Array<int>& marker)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalSourceFaceIBFIOneNormalOperators<BF>(global, marker, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalSourceFaceIBFIOneNormalOperators(SparseMatrix* global, mfem::Array<int>& marker, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			for (auto x{ X }; x <= Z; x++) {
+				if (x >= dim) continue;
 				auto y = (x + 1) % 3;
 				auto z = (x + 2) % 3;
 				auto op = buildByMult<FES,BF>(MInv[f]->SpMat(), buildSourceFaceIBFIOneNormalSubOperator<BF>(altField(f), { x }, marker)->SpMat(), fes_);
@@ -845,11 +1021,21 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalSourceFaceIBFITwoNormalOperators(SparseMatrix* global, mfem::Array<int>& marker)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalSourceFaceIBFITwoNormalOperators<BF>(global, marker, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalSourceFaceIBFITwoNormalOperators(SparseMatrix* global, mfem::Array<int>& marker, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			for (auto d{ X }; d <= Z; d++) {
+				if (d >= dim) continue;
 				for (auto d2{ X }; d2 <= Z; d2++) {
+					if (d2 >= dim) continue;
 					auto op = buildByMult<FES,BF>(MInv[f]->SpMat(), buildSourceFaceIBFITwoNormalSubOperator<BF>(f, { d, d2 }, marker)->SpMat(), fes_);
 					loadBlockInGlobalAtIndices(
 						op->SpMat(),
@@ -866,10 +1052,19 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalDirectionalOperators(SparseMatrix* global)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalDirectionalOperators<BF>(global, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalDirectionalOperators(SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			for (auto x{ X }; x <= Z; x++) {
+				if (x >= dim) continue; // S2: derivative in direction x is zero beyond mesh dimension
 				auto y = (x + 1) % 3;
 				auto z = (x + 2) % 3;
 				auto op = buildByMult<FES,BF>(
@@ -894,9 +1089,16 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalZeroNormalOperators(SparseMatrix* global)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalZeroNormalOperators<BF>(global, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalZeroNormalOperators(SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs());
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			auto op = buildByMult<FES,BF>(
 				MInv[f]->SpMat(), buildZeroNormalSubOperator<BF>(f)->SpMat(), fes_);
 			for (auto d : { X, Y, Z }) {
@@ -914,11 +1116,19 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalOneNormalOperators(SparseMatrix* global)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalOneNormalOperators<BF>(global, MInv);
+	}
 
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalOneNormalOperators(SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs());
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			for (auto x{ X }; x <= Z; x++) {
+				if (x >= dim) continue; // S2: normal component x is zero in lower dimensions
 				auto y = (x + 1) % 3;
 				auto z = (x + 2) % 3;
 				auto op = buildByMult<FES,BF>(
@@ -943,12 +1153,21 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalTwoNormalOperators(SparseMatrix* global)
 	{
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalTwoNormalOperators<BF>(global, MInv);
+	}
 
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalTwoNormalOperators(SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
 		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs());
 		for (auto f : { E, H }) {
-			auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
 			for (auto d{ X }; d <= Z; d++) {
+				if (d >= dim) continue; // S2: normal component d is zero in lower dimensions
 				for (auto d2{ X }; d2 <= Z; d2++) {
+					if (d2 >= dim) continue; // S2: normal component d2 is zero in lower dimensions
 					auto op = buildByMult<FES,BF>(
 						MInv[f]->SpMat(), buildTwoNormalSubOperator<BF>(f, {d, d2})->SpMat(), fes_);
 					loadBlockInGlobalAtIndices(
@@ -966,9 +1185,16 @@ namespace maxwell
 	template <typename BF>
 	void DGOperatorFactory<FES>::addGlobalConductiveOperator(mfem::SparseMatrix* global)
 	{
-		auto MInvE = buildInverseMassMatrixSubOperator<BF>(FieldType::E);
+		auto MInv = buildMaxwellInverseMassMatrixOperator<BF>();
+		addGlobalConductiveOperator<BF>(global, MInv);
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::addGlobalConductiveOperator(mfem::SparseMatrix* global, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
 		auto MSig  = buildSigmaMassOperator<BF>();
-		auto ASigE = buildByMult<FES, BF>(MInvE->SpMat(), MSig->SpMat(), fes_);
+		auto ASigE = buildByMult<FES, BF>(MInv[E]->SpMat(), MSig->SpMat(), fes_);
 
 		GlobalIndices gid(fes_.GetNDofs(), getAdditionalDofs(), true);
 		for (auto d : { X, Y, Z }) {
@@ -978,6 +1204,159 @@ namespace maxwell
 				std::make_pair(*gid.offsets[E][d].get(), *gid.offsets[E][d].get()),
 				-1.0
 			);
+		}
+	}
+
+	// ======= S1: collectGlobal* variants for CSR-direct assembly =======
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::collectGlobalZeroNormalIBFIOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
+		for (auto f : { E, H }) {
+			auto op = buildByMult<FES,BF>(
+				MInv[f]->SpMat(), buildZeroNormalIBFISubOperator<BF>(f)->SpMat(), fes_);
+			for (auto d : { X, Y, Z }) {
+				collectBlockPlacement(op->SpMat(), blocks,
+					std::make_pair(*globalId.offsets[f][d].get(), *globalId.offsets[f][d].get()), -1.0);
+			}
+		}
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::collectGlobalOneNormalIBFIOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
+		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
+		for (auto f : { E, H }) {
+			for (auto x{ X }; x <= Z; x++) {
+				if (x >= dim) continue;
+				auto y = (x + 1) % 3;
+				auto z = (x + 2) % 3;
+				auto op = buildByMult<FES,BF>(MInv[f]->SpMat(), buildOneNormalIBFISubOperator<BF>(altField(f), { x })->SpMat(), fes_);
+				collectBlockPlacement(op->SpMat(), blocks,
+					std::make_pair(*globalId.offsets[f][y].get(), *globalId.offsets[altField(f)][z].get()),
+					1.0 - double(f) * 2.0);
+				collectBlockPlacement(op->SpMat(), blocks,
+					std::make_pair(*globalId.offsets[f][z].get(), *globalId.offsets[altField(f)][y].get()),
+					-1.0 + double(f) * 2.0);
+			}
+		}
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::collectGlobalTwoNormalIBFIOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
+		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
+		for (auto f : { E, H }) {
+			for (auto d{ X }; d <= Z; d++) {
+				if (d >= dim) continue;
+				for (auto d2{ X }; d2 <= Z; d2++) {
+					if (d2 >= dim) continue;
+					auto op = buildByMult<FES,BF>(MInv[f]->SpMat(), buildTwoNormalIBFISubOperator<BF>(f, { d, d2 })->SpMat(), fes_);
+					collectBlockPlacement(op->SpMat(), blocks,
+						std::make_pair(*globalId.offsets[f][d].get(), *globalId.offsets[f][d2].get()), 1.0);
+				}
+			}
+		}
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::collectGlobalDirectionalOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
+		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs(), true);
+		for (auto f : { E, H }) {
+			for (auto x{ X }; x <= Z; x++) {
+				if (x >= dim) continue;
+				auto y = (x + 1) % 3;
+				auto z = (x + 2) % 3;
+				auto op = buildByMult<FES,BF>(
+					MInv[f]->SpMat(), buildDerivativeSubOperator<BF>(x)->SpMat(), fes_);
+				collectBlockPlacement(op->SpMat(), blocks,
+					std::make_pair(*globalId.offsets[f][z].get(), *globalId.offsets[altField(f)][y].get()),
+					1.0 - double(f) * 2.0);
+				collectBlockPlacement(op->SpMat(), blocks,
+					std::make_pair(*globalId.offsets[f][y].get(), *globalId.offsets[altField(f)][z].get()),
+					-1.0 + double(f) * 2.0);
+			}
+		}
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::collectGlobalZeroNormalOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs());
+		for (auto f : { E, H }) {
+			auto op = buildByMult<FES,BF>(
+				MInv[f]->SpMat(), buildZeroNormalSubOperator<BF>(f)->SpMat(), fes_);
+			for (auto d : { X, Y, Z }) {
+				collectBlockPlacement(op->SpMat(), blocks,
+					std::make_pair(*globalId.offsets[f][d].get(), *globalId.offsets[f][d].get()), -1.0);
+			}
+		}
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::collectGlobalOneNormalOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
+		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs());
+		for (auto f : { E, H }) {
+			for (auto x{ X }; x <= Z; x++) {
+				if (x >= dim) continue;
+				auto y = (x + 1) % 3;
+				auto z = (x + 2) % 3;
+				auto op = buildByMult<FES,BF>(
+					MInv[f]->SpMat(), buildOneNormalSubOperator<BF>(altField(f), { x })->SpMat(), fes_);
+				collectBlockPlacement(op->SpMat(), blocks,
+					std::make_pair(*globalId.offsets[f][y].get(), *globalId.offsets[altField(f)][z].get()),
+					1.0 - double(f) * 2.0);
+				collectBlockPlacement(op->SpMat(), blocks,
+					std::make_pair(*globalId.offsets[f][z].get(), *globalId.offsets[altField(f)][y].get()),
+					-1.0 + double(f) * 2.0);
+			}
+		}
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::collectGlobalTwoNormalOperators(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		const int dim = meshDimension();
+		GlobalIndices globalId(fes_.GetNDofs(), getAdditionalDofs());
+		for (auto f : { E, H }) {
+			for (auto d{ X }; d <= Z; d++) {
+				if (d >= dim) continue;
+				for (auto d2{ X }; d2 <= Z; d2++) {
+					if (d2 >= dim) continue;
+					auto op = buildByMult<FES,BF>(
+						MInv[f]->SpMat(), buildTwoNormalSubOperator<BF>(f, {d, d2})->SpMat(), fes_);
+					collectBlockPlacement(op->SpMat(), blocks,
+						std::make_pair(*globalId.offsets[f][d].get(), *globalId.offsets[f][d2].get()), 1.0);
+				}
+			}
+		}
+	}
+
+	template <typename FES>
+	template <typename BF>
+	void DGOperatorFactory<FES>::collectGlobalConductiveOperator(std::vector<CSRBlockPlacement>& blocks, const std::array<std::unique_ptr<BF>, 2>& MInv)
+	{
+		auto MSig  = buildSigmaMassOperator<BF>();
+		auto ASigE = buildByMult<FES, BF>(MInv[E]->SpMat(), MSig->SpMat(), fes_);
+
+		GlobalIndices gid(fes_.GetNDofs(), getAdditionalDofs(), true);
+		for (auto d : { X, Y, Z }) {
+			collectBlockPlacement(ASigE->SpMat(), blocks,
+				std::make_pair(*gid.offsets[E][d].get(), *gid.offsets[E][d].get()), -1.0);
 		}
 	}
 
@@ -1027,14 +1406,18 @@ namespace maxwell
 	{
 		std::unique_ptr<SparseMatrix> res = std::make_unique<SparseMatrix>(6 * fes_.GetNDofs(), 6 * (fes_.GetNDofs() + getAdditionalDofs()));
 
+		// S5: Build M^{-1} once and share across all sub-operator assemblies.
+		auto MInv = buildMaxwellInverseMassMatrixOperator<ParBilinearForm>();
+
 		if constexpr (std::is_same_v<FES, ParFiniteElementSpace>) {
-			this->template addGlobalSourceFaceIBFIOneNormalOperators<ParBilinearForm>(res.get(), marker);
-			this->template addGlobalSourceFaceIBFIZeroNormalOperators<ParBilinearForm>(res.get(), marker);
-			this->template addGlobalSourceFaceIBFITwoNormalOperators<ParBilinearForm>(res.get(), marker);
+			this->template addGlobalSourceFaceIBFIOneNormalOperators<ParBilinearForm>(res.get(), marker, MInv);
+			this->template addGlobalSourceFaceIBFIZeroNormalOperators<ParBilinearForm>(res.get(), marker, MInv);
+			this->template addGlobalSourceFaceIBFITwoNormalOperators<ParBilinearForm>(res.get(), marker, MInv);
 		} else {
-			this->template addGlobalSourceFaceIBFIOneNormalOperators<BilinearForm>(res.get(), marker);
-			this->template addGlobalSourceFaceIBFIZeroNormalOperators<BilinearForm>(res.get(), marker);
-			this->template addGlobalSourceFaceIBFITwoNormalOperators<BilinearForm>(res.get(), marker);
+			auto MInvSerial = buildMaxwellInverseMassMatrixOperator<BilinearForm>();
+			this->template addGlobalSourceFaceIBFIOneNormalOperators<BilinearForm>(res.get(), marker, MInvSerial);
+			this->template addGlobalSourceFaceIBFIZeroNormalOperators<BilinearForm>(res.get(), marker, MInvSerial);
+			this->template addGlobalSourceFaceIBFITwoNormalOperators<BilinearForm>(res.get(), marker, MInvSerial);
 		}
 
 		res->Finalize();
@@ -1049,8 +1432,15 @@ namespace maxwell
 			fes_.ExchangeFaceNbrData();
     	}
 
-		std::unique_ptr<SparseMatrix> res = std::make_unique<SparseMatrix>(6 * fes_.GetNDofs(), 6 * (fes_.GetNDofs() + getAdditionalDofs()));
+		const int globalRows = 6 * fes_.GetNDofs();
+		const int globalCols = 6 * (fes_.GetNDofs() + getAdditionalDofs());
 
+		// S1: Collect all sub-operator block placements, then merge into CSR directly
+		// (avoids LIL intermediate representation and its 2x peak memory during Finalize).
+		std::vector<CSRBlockPlacement> blocks;
+
+		// S5: Build M^{-1} once and share across all sub-operator assemblies.
+		auto MInv = buildMaxwellInverseMassMatrixOperator<ParBilinearForm>();
 
 		if (pd_.model.getInteriorBoundaryToMarker().size() != 0) { //IntBdrConds
 
@@ -1067,7 +1457,7 @@ namespace maxwell
 			}
 			#endif
 
-				this->template	addGlobalOneNormalIBFIOperators<ParBilinearForm>(res.get());
+				this->template	collectGlobalOneNormalIBFIOperators<ParBilinearForm>(blocks, MInv);
 
 			#ifdef SHOW_TIMER_INFORMATION
 			if (!pd_.opts.is_sgbc_solver && Mpi::WorldRank() == 0){
@@ -1078,7 +1468,7 @@ namespace maxwell
 			}
 			#endif
 
-				this->template	addGlobalZeroNormalIBFIOperators<ParBilinearForm>(res.get());
+				this->template	collectGlobalZeroNormalIBFIOperators<ParBilinearForm>(blocks, MInv);
 
 			#ifdef SHOW_TIMER_INFORMATION
 			if (!pd_.opts.is_sgbc_solver && Mpi::WorldRank() == 0){
@@ -1089,7 +1479,7 @@ namespace maxwell
 			}
 			#endif
 
-				this->template	addGlobalTwoNormalIBFIOperators<ParBilinearForm>(res.get());
+				this->template	collectGlobalTwoNormalIBFIOperators<ParBilinearForm>(blocks, MInv);
 
 			#ifdef SHOW_TIMER_INFORMATION
 			if (!pd_.opts.is_sgbc_solver && Mpi::WorldRank() == 0){
@@ -1117,7 +1507,7 @@ namespace maxwell
 		}
 		#endif
 
-		this->template	addGlobalDirectionalOperators<ParBilinearForm>(res.get());
+		this->template	collectGlobalDirectionalOperators<ParBilinearForm>(blocks, MInv);
 
 		#ifdef SHOW_TIMER_INFORMATION
 		if (!pd_.opts.is_sgbc_solver && Mpi::WorldRank() == 0){
@@ -1128,7 +1518,7 @@ namespace maxwell
 		}
 		#endif
 
-		this->template	addGlobalOneNormalOperators<ParBilinearForm>(res.get());
+		this->template	collectGlobalOneNormalOperators<ParBilinearForm>(blocks, MInv);
 
 		#ifdef SHOW_TIMER_INFORMATION
 		if (!pd_.opts.is_sgbc_solver && Mpi::WorldRank() == 0){
@@ -1139,7 +1529,7 @@ namespace maxwell
 		}
 		#endif
 
-		this->template	addGlobalZeroNormalOperators<ParBilinearForm>(res.get());
+		this->template	collectGlobalZeroNormalOperators<ParBilinearForm>(blocks, MInv);
 
 		#ifdef SHOW_TIMER_INFORMATION
 		if (!pd_.opts.is_sgbc_solver && Mpi::WorldRank() == 0){
@@ -1150,7 +1540,7 @@ namespace maxwell
 		}
 		#endif
 
-		this->template	addGlobalTwoNormalOperators<ParBilinearForm>(res.get());
+		this->template	collectGlobalTwoNormalOperators<ParBilinearForm>(blocks, MInv);
 
 		#ifdef SHOW_TIMER_INFORMATION
 		if (!pd_.opts.is_sgbc_solver && Mpi::WorldRank() == 0){
@@ -1161,17 +1551,21 @@ namespace maxwell
 		}
 		#endif
 
-		this->template  addGlobalConductiveOperator<ParBilinearForm>(res.get());
+		this->template  collectGlobalConductiveOperator<ParBilinearForm>(blocks, MInv);
 
 		#ifdef SHOW_TIMER_INFORMATION
 		if (!pd_.opts.is_sgbc_solver && Mpi::WorldRank() == 0){
 			std::cout << "Elapsed time (ms): " << std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>
 				(std::chrono::high_resolution_clock::now() - startTime).count()) << std::endl;
-			std::cout << "All operators assembled. Finalising global operator matrix." << std::endl;
+			std::cout << "All operators assembled. Merging into global CSR matrix." << std::endl;
 		}
 		#endif
 
-		res->Finalize();
+		auto res = mergeBlocksToCSR(blocks, globalRows, globalCols);
+
+		// Free sub-operator blocks before applying threshold.
+		blocks.clear();
+
 		auto threshold = 1e-20;
 		res->Threshold(threshold);
 

--- a/src/evolution/GlobalEvolution.cpp
+++ b/src/evolution/GlobalEvolution.cpp
@@ -541,10 +541,10 @@ void GlobalEvolution::applyTFSFSourceToVector(double t_stage, int ndofs, int nbr
     const int blockSize = ndofs + nbrDofs;
 
     // Ensure global-layout planewave vector is allocated (first call only)
-    if (tfsf_assembledFunc_.Size() != 6 * blockSize) {
-        tfsf_assembledFunc_.SetSize(6 * blockSize);
-        tfsf_assembledFunc_.UseDevice(true);
-        tfsf_assembledFunc_ = 0.0;
+    if (multWorkVec_.Size() != 6 * blockSize) {
+        multWorkVec_.SetSize(6 * blockSize);
+        multWorkVec_.UseDevice(true);
+        multWorkVec_ = 0.0;
     }
     // Vector is already zero: either freshly initialized above,
     // or cleaned after the previous AddMult call below.
@@ -578,30 +578,30 @@ void GlobalEvolution::applyTFSFSourceToVector(double t_stage, int ndofs, int nbr
         }
     }
 
-    // Scatter submesh planewave values into tfsf_assembledFunc_ (local DOFs only;
+    // Scatter submesh planewave values into multWorkVec_ (local DOFs only;
     // partitioner guarantees all TFSF faces are rank-local, no ghost exchange needed).
 #ifdef SEMBA_DGTD_ENABLE_CUDA
-    scatter_tfsf_to_assembled_gpu(tfsf_sub_to_parent_ids_, func, tfsf_assembledFunc_, blockSize);
+    scatter_tfsf_to_assembled_gpu(tfsf_sub_to_parent_ids_, func, multWorkVec_, blockSize);
 #else
     for (int v = 0; v < tfsf_sub_to_parent_ids_.Size(); ++v) {
         const int parent_dof = tfsf_sub_to_parent_ids_[v];
         for (int d : {X, Y, Z}) {
-            tfsf_assembledFunc_[d * blockSize + parent_dof] = func[E][d][v];
-            tfsf_assembledFunc_[(3 + d) * blockSize + parent_dof] = func[H][d][v];
+            multWorkVec_[d * blockSize + parent_dof] = func[E][d][v];
+            multWorkVec_[(3 + d) * blockSize + parent_dof] = func[H][d][v];
         }
     }
 #endif
 
     // Apply TFSF operator and subtract from result: out -= TFSFOp * planewave
-    TFSFOperator_->AddMult(tfsf_assembledFunc_, result_vector, -1.0);
+    TFSFOperator_->AddMult(multWorkVec_, result_vector, -1.0);
 
     // Restore zeroed state for next call
 #ifdef SEMBA_DGTD_ENABLE_CUDA
-    zero_tfsf_assembled_gpu(tfsf_sub_to_parent_ids_, tfsf_assembledFunc_, blockSize);
+    zero_tfsf_assembled_gpu(tfsf_sub_to_parent_ids_, multWorkVec_, blockSize);
 #else
     for (int d = X; d <= Z; ++d) {
-        std::memset(tfsf_assembledFunc_.GetData() + d * blockSize, 0, blockSize * sizeof(double));
-        std::memset(tfsf_assembledFunc_.GetData() + (3 + d) * blockSize, 0, blockSize * sizeof(double));
+        std::memset(multWorkVec_.GetData() + d * blockSize, 0, blockSize * sizeof(double));
+        std::memset(multWorkVec_.GetData() + (3 + d) * blockSize, 0, blockSize * sizeof(double));
     }
 #endif
 }
@@ -624,11 +624,6 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
 #endif
     bool sgbc_all_quiescent = false;
     if (SGBCOperator_ && !sgbcWrappers_.empty()){
-        if (sgbcVec_.Size() != 6 * blockSize) {
-            sgbcVec_.SetSize(6 * blockSize);
-            sgbcVec_.UseDevice(true);
-            sgbcVec_ = 0.0;
-        }
 
         double t_stage = GetTime();
         double dt_to_stage = t_stage - sgbc_step_base_time_;
@@ -762,26 +757,26 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
     timerExchange.Stop();
 #endif
 
-    // 3) Assemble inNew_ (local + neighbor data)
-    if (inNew_.Size() != 6 * blockSize) {
-        inNew_.SetSize(6 * blockSize);
-        inNew_.UseDevice(true);
+    // 3) Assemble multWorkVec_ (local + neighbor data)
+    if (multWorkVec_.Size() != 6 * blockSize) {
+        multWorkVec_.SetSize(6 * blockSize);
+        multWorkVec_.UseDevice(true);
     }
 
 #ifdef SEMBA_DGTD_ENABLE_CUDA
-    load_eh_to_innew_gpu(in, inNew_, ndofs, nbrDofs);
-    load_nbr_to_innew_gpu(eOld_, hOld_, inNew_, ndofs, nbrDofs);
+    load_eh_to_innew_gpu(in, multWorkVec_, ndofs, nbrDofs);
+    load_nbr_to_innew_gpu(eOld_, hOld_, multWorkVec_, ndofs, nbrDofs);
 #else
     for (int d = X; d <= Z; ++d) {
-        inNew_.SetVector(eOld_[d],       d      * blockSize);
-        inNew_.SetVector(hOld_[d],  (3 + d)     * blockSize);
+        multWorkVec_.SetVector(eOld_[d],       d      * blockSize);
+        multWorkVec_.SetVector(hOld_[d],  (3 + d)     * blockSize);
     }
     if (nbrDofs) {
         for (int d = X; d <= Z; ++d) {
             mfem::Vector &eNbr = eOld_[d].FaceNbrData();
             mfem::Vector &hNbr = hOld_[d].FaceNbrData();
-            inNew_.SetVector(eNbr,      d      * blockSize + ndofs);
-            inNew_.SetVector(hNbr, (3 + d)     * blockSize + ndofs);
+            multWorkVec_.SetVector(eNbr,      d      * blockSize + ndofs);
+            multWorkVec_.SetVector(hNbr, (3 + d)     * blockSize + ndofs);
         }
     }
 #endif
@@ -794,10 +789,13 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
         out.SetSize(6 * ndofs);
         out.UseDevice(true);
     }
-    globalOperator_->Mult(inNew_, out);
+    globalOperator_->Mult(multWorkVec_, out);
 #ifdef SHOW_TIMER_INFORMATION
     timerApplyA.Stop();
 #endif
+
+    // S3: Zero multWorkVec_ so it can be reused for TFSF and SGBC injection.
+    multWorkVec_ = 0.0;
 
     // 5) TFSF source injection
 #ifdef SHOW_TIMER_INFORMATION
@@ -812,19 +810,15 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
     //    Sub-solve was done in step 1; here we only inject interface values as flux.
     //    Skip entirely when all SGBC faces are quiescent.
     if (SGBCOperator_ && !sgbcWrappers_.empty() && !sgbc_all_quiescent){
-        if (sgbcVec_.Size() != 6 * blockSize) {
-            sgbcVec_.SetSize(6 * blockSize);
-            sgbcVec_.UseDevice(true);
-            sgbcVec_ = 0.0;
-        }
+        // multWorkVec_ is already sized and zeroed (after step 4 zeroing + TFSF cleanup).
         // On GPU builds 'in' is device-authoritative after steps 2-5; HostRead()
         // syncs device→host once for all operator[]-based DOF reads below.
-        // sgbcVec_ was zeroed on device; HostReadWrite() syncs it to host so that
+        // multWorkVec_ was zeroed on device; HostReadWrite() syncs it to host so that
         // operator[] assignments write to the correct (host) buffer.
         in.HostRead();
-        sgbcVec_.HostReadWrite();
+        multWorkVec_.HostReadWrite();
 
-        // Helper: fill sgbcVec_ slot for a given BC type.
+        // Helper: fill multWorkVec_ slot for a given BC type.
         // For PEC/PMC/SMA: mirror/absorb from global field at source_dof.
         // For transparent (SGBC): rotate slab interior field at slab_idx to global frame.
         auto fillBCSlot = [&](BdrCond bdr, int source_dof, int target_slot,
@@ -832,18 +826,18 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
                               int local_size, int slab_idx) {
             if (bdr == BdrCond::PEC) {
                 for (int d = X; d <= Z; ++d) {
-                    sgbcVec_[d * blockSize + target_slot]       = -in[d * ndofs + source_dof];
-                    sgbcVec_[(3 + d) * blockSize + target_slot] =  in[(3 + d) * ndofs + source_dof];
+                    multWorkVec_[d * blockSize + target_slot]       = -in[d * ndofs + source_dof];
+                    multWorkVec_[(3 + d) * blockSize + target_slot] =  in[(3 + d) * ndofs + source_dof];
                 }
             } else if (bdr == BdrCond::PMC) {
                 for (int d = X; d <= Z; ++d) {
-                    sgbcVec_[d * blockSize + target_slot]       =  in[d * ndofs + source_dof];
-                    sgbcVec_[(3 + d) * blockSize + target_slot] = -in[(3 + d) * ndofs + source_dof];
+                    multWorkVec_[d * blockSize + target_slot]       =  in[d * ndofs + source_dof];
+                    multWorkVec_[(3 + d) * blockSize + target_slot] = -in[(3 + d) * ndofs + source_dof];
                 }
             } else if (bdr == BdrCond::SMA) {
                 for (int d = X; d <= Z; ++d) {
-                    sgbcVec_[d * blockSize + target_slot]       = in[d * ndofs + source_dof];
-                    sgbcVec_[(3 + d) * blockSize + target_slot] = in[(3 + d) * ndofs + source_dof];
+                    multWorkVec_[d * blockSize + target_slot]       = in[d * ndofs + source_dof];
+                    multWorkVec_[(3 + d) * blockSize + target_slot] = in[(3 + d) * ndofs + source_dof];
                 }
             } else {
                 // Transparent: rotate slab local→global
@@ -853,17 +847,17 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
                     hl[d] = fields_state[(3 + d) * local_size + slab_idx];
                 }
                 for (int d = 0; d < 3; ++d) {
-                    sgbcVec_[d * blockSize + target_slot]       = rot[d]*el[0] + rot[3+d]*el[1] + rot[6+d]*el[2];
-                    sgbcVec_[(3 + d) * blockSize + target_slot] = rot[d]*hl[0] + rot[3+d]*hl[1] + rot[6+d]*hl[2];
+                    multWorkVec_[d * blockSize + target_slot]       = rot[d]*el[0] + rot[3+d]*el[1] + rot[6+d]*el[2];
+                    multWorkVec_[(3 + d) * blockSize + target_slot] = rot[d]*hl[0] + rot[3+d]*hl[1] + rot[6+d]*hl[2];
                 }
             }
         };
 
-        // Helper: copy global field values into sgbcVec_ slot
+        // Helper: copy global field values into multWorkVec_ slot
         auto copyGlobalSlot = [&](int dof, int slot) {
             for (int d = X; d <= Z; ++d) {
-                sgbcVec_[d * blockSize + slot] = in[d * ndofs + dof];
-                sgbcVec_[(3 + d) * blockSize + slot] = in[(3 + d) * ndofs + dof];
+                multWorkVec_[d * blockSize + slot] = in[d * ndofs + dof];
+                multWorkVec_[(3 + d) * blockSize + slot] = in[(3 + d) * ndofs + dof];
             }
         };
 
@@ -890,7 +884,7 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
         }
         // Targeted SpMV: only compute rows for Elem1 DOFs, add directly to out.
         {
-            const double* sv = sgbcVec_.HostRead();
+            const double* sv = multWorkVec_.HostRead();
             double* op = out.HostReadWrite();
             for (int comp = 0; comp < 6; ++comp) {
                 for (int dof : sgbc_elem1_dofs_) {
@@ -913,11 +907,11 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
                 int gl = state.global_pair.first;
                 int gr = state.global_pair.second;
                 for (int d = X; d <= Z; ++d) {
-                    sgbcVec_[d * blockSize + gl] = 0.0;
-                    sgbcVec_[(3 + d) * blockSize + gl] = 0.0;
+                    multWorkVec_[d * blockSize + gl] = 0.0;
+                    multWorkVec_[(3 + d) * blockSize + gl] = 0.0;
                     if (gr != -1) {
-                        sgbcVec_[d * blockSize + gr] = 0.0;
-                        sgbcVec_[(3 + d) * blockSize + gr] = 0.0;
+                        multWorkVec_[d * blockSize + gr] = 0.0;
+                        multWorkVec_[(3 + d) * blockSize + gr] = 0.0;
                     }
                 }
             }
@@ -948,7 +942,7 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
         }
         // Targeted SpMV: only compute rows for Elem2 DOFs, add directly to out.
         {
-            const double* sv = sgbcVec_.HostRead();
+            const double* sv = multWorkVec_.HostRead();
             double* op = out.HostReadWrite();
             for (int comp = 0; comp < 6; ++comp) {
                 for (int dof : sgbc_elem2_dofs_) {
@@ -965,17 +959,17 @@ void GlobalEvolution::Mult(const mfem::Vector& in, mfem::Vector& out) const
             }
         }
 
-        // Clear entries written in Pass 2 so sgbcVec_ stays zeroed for next call
+        // Clear entries written in Pass 2 so multWorkVec_ stays zeroed for next call
         for (auto& [tag, states] : sgbc_states_) {
             for (const auto& state : states) {
                 int gl = state.global_pair.first;
                 int gr = state.global_pair.second;
                 if (gr == -1) continue;
                 for (int d = X; d <= Z; ++d) {
-                    sgbcVec_[d * blockSize + gl] = 0.0;
-                    sgbcVec_[(3 + d) * blockSize + gl] = 0.0;
-                    sgbcVec_[d * blockSize + gr] = 0.0;
-                    sgbcVec_[(3 + d) * blockSize + gr] = 0.0;
+                    multWorkVec_[d * blockSize + gl] = 0.0;
+                    multWorkVec_[(3 + d) * blockSize + gl] = 0.0;
+                    multWorkVec_[d * blockSize + gr] = 0.0;
+                    multWorkVec_[(3 + d) * blockSize + gr] = 0.0;
                 }
             }
         }

--- a/src/evolution/GlobalEvolution.h
+++ b/src/evolution/GlobalEvolution.h
@@ -81,9 +81,7 @@ private:
 
     mutable std::array<mfem::ParGridFunction, 3> eOld_, hOld_;
 
-    mutable mfem::Vector inNew_;
-    mutable mfem::Vector sgbcVec_;
-    mutable mfem::Vector tfsf_assembledFunc_;
+    mutable mfem::Vector multWorkVec_;
 
     // ImplicitSolve reusable work vectors (avoid per-call allocation)
     mutable mfem::Vector implicit_inNew_;

--- a/src/solver/Solver.cpp
+++ b/src/solver/Solver.cpp
@@ -1,10 +1,14 @@
 #include "Solver.h"
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <unistd.h>
 #include <cmath>
 
 namespace maxwell {
+
+size_t getCurrentMemoryUsage();
+size_t getPeakMemoryUsage();
 
 Solver::~Solver() = default; 
 
@@ -136,6 +140,7 @@ Solver::Solver(
             myfile << std::scientific << std::setprecision(5);
             myfile << "Initialization Time: " << runtime << " (s)\n";
             myfile << std::defaultfloat;
+            myfile << "Assembly Peak Memory Consumption (B): " << getPeakMemoryUsage() << "\n";
             myfile.close();
         } else {
             std::cerr << "Rank " << comm_rank << " failed to open file: " << path << "\n";
@@ -379,6 +384,23 @@ size_t getCurrentMemoryUsage() {
 #endif
 }
 
+size_t getPeakMemoryUsage() {
+#ifdef SEMBA_DGTD_ENABLE_CUDA
+    return getCurrentMemoryUsage(); // No peak tracking available; report current GPU usage.
+#else
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.rfind("VmHWM:", 0) == 0) {
+            long kb = 0;
+            std::istringstream(line.substr(6)) >> kb;
+            return static_cast<size_t>(kb * 1024);
+        }
+    }
+    return 0;
+#endif
+}
+
 void Solver::writeSimulationStatistics(const Time runtime){
     // Skip writing statistics for SGBC sub-solvers
     if (opts_.is_sgbc_solver) {
@@ -415,7 +437,7 @@ void Solver::writeSimulationStatistics(const Time runtime){
             std::int64_t non_zero_elems = static_cast<std::int64_t>(global->getConstGlobalOperator().NumNonZeroElems());
             myfile << "Number of Operator Non-Zero Elements: " << non_zero_elems << "\n";
         }
-        myfile << "Memory Consumption (B): " << getCurrentMemoryUsage() << "\n";
+        myfile << "Temporal Evolution Memory Consumption (B): " << getCurrentMemoryUsage() << "\n";
         myfile.close();
     } else {
         std::cerr << "Rank " << rank << " failed to open file: " << path << "\n";


### PR DESCRIPTION
- Replaced multiple mutable vectors (inNew_, sgbcVec_, tfsf_assembledFunc_) with a single mutable vector (multWorkVec_) in GlobalEvolution.h and updated all relevant methods in GlobalEvolution.cpp to utilize this new vector.
- This change simplifies memory management and reduces overhead by reusing the same vector for different operations.
- Added memory usage tracking functions in Solver.cpp to report current and peak memory consumption during simulation initialization and execution.